### PR TITLE
Fix prune command so that it doesn't delete original command message

### DIFF
--- a/commands/prune.js
+++ b/commands/prune.js
@@ -8,8 +8,8 @@ module.exports = (self) => {
 
     // Prune msgs
     msg.channel.getMessages(200).then(msgs => {
-      let msgArray = msgs.filter(m => m.author.id === this.self.user.id)
-      msgArray.length = parseInt(args[0], 10) + 1
+      let msgArray = msgs.filter(m => m.author.id === this.self.user.id).filter(m => m !== msgs[0])
+      msgArray.length = parseInt(args[0], 10)
       msgArray.map(m => m.delete().catch(err => this.log.err(err)))
     })
   })


### PR DESCRIPTION
The msgs array starts with the last message sent to the channel, which is always the command last sent.
Fixes #18 