### PR TITLE
Update the Limit of Command.js

### DIFF
--- a/src/Command.js
+++ b/src/Command.js
@@ -61,7 +61,7 @@ class Command {
 
   send (msg, content, deleteDelay = 0) {
     deleteDelay = deleteDelay || this.config.deleteCommandMessagesTime
-    if (content.length > 20000) {
+    if (content.length > 2000) {
       this.log.err('Error sending a message larger than the limit (2000+)')
       return
     }


### PR DESCRIPTION
It looks like an Error to me:

I mean the limit of the Discord Client is 2000 Characters. Not 20000.
if i am wrong dont punch me.